### PR TITLE
prevent Changelog Enforcer from triggering on push events

### DIFF
--- a/.github/workflows/changelog_enforcer.yml
+++ b/.github/workflows/changelog_enforcer.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - release-*
-  push:
-    branches:
-      - main
-      - release-*
+
+# TODO: This is currently not supported, see https://github.com/dangoslen/changelog-enforcer/issues/210.
+#  push:
+#    branches:
+#      - main
+#      - release-*
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ### Fixed -->
 <!-- markdownlint-disable-next-line -->
+### Fixed
+
+- Prevent Changelog Enforcer from triggering on `push` events
 
 <!-- ### Security -->
 <!-- markdownlint-disable-next-line -->


### PR DESCRIPTION
**About this change—what it does?**

<!-- Please include a summary of the change and which issue is fixed, relevant motivation and context. Don't forget to list any dependencies that are required for this change. -->
prevents Changelog Enforcer from triggering on push events as it's currently not supported

see #64 and https://github.com/dangoslen/changelog-enforcer/issues/210

**What type of change is it?**

<!-- Please delete options that are not relevant. -->

- [x] Bug fix, i.e. non-breaking change which fixes an issue

- [ ] This change requires a documentation update

**Have you checked yourself twice?**

<!-- Please check all the boxes before opening the PR. -->

- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My code follows the contributing guidelines of this project
